### PR TITLE
adding additional include for improved usability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ else:
 	py3k=(sys.version_info[0]==3)
 	libraries=['boost_python-py3%d'%sys.version_info[1] if py3k else 'boost_python']
 	library_dirs=[]
-	include_dirs=['/usr/include/eigen3','minieigen']
+	include_dirs=['/usr/include/eigen3','/usr/local/include/eigen3','minieigen']
 
 setup(name='minieigen',
 	version='0.5.2',


### PR DESCRIPTION
Adding `/usr/local/include/eigen3` as it is the default include dir under Mac OS X, when using the widely popular **homebrew** package manager. Of course one could also manually sym-link into `/usr/include`, but this is a simple usability improvement for anyone trying to install `minieigen` through `pip`.
