### PR TITLE
Allow high precision Real types in Yade.

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -1,7 +1,7 @@
 #pragma once
 // common types, funcs, includes; should be included by all other files
 
-#ifndef MINIEIGEN_OVERRIDE
+#ifndef _HIGH_PRECISION_SUPPORT
 /* change to float for single-precision */
 typedef double Real;
 #endif
@@ -22,7 +22,7 @@ typedef double Real;
 
 #include<unsupported/Eigen/AlignedVector3>
 
-#ifndef MINIEIGEN_OVERRIDE
+#ifndef _HIGH_PRECISION_SUPPORT
 // integral type for indices, to avoid compiler warnings with int
 typedef Eigen::Matrix<int,1,1>::Index Index;
 
@@ -75,7 +75,7 @@ namespace py=boost::python;
 using boost::lexical_cast;
 #include<boost/static_assert.hpp>
 
-#ifndef MINIEIGEN_OVERRIDE
+#ifndef _HIGH_PRECISION_SUPPORT
 /**** double-conversion helpers *****/
 #include"double-conversion/double-conversion.h"
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -1,8 +1,10 @@
 #pragma once
 // common types, funcs, includes; should be included by all other files
 
+#ifndef MINIEIGEN_OVERRIDE
 /* change to float for single-precision */
 typedef double Real;
+#endif
 
 // BEGIN workaround for
 // * http://eigen.tuxfamily.org/bz/show_bug.cgi?id=528
@@ -20,6 +22,7 @@ typedef double Real;
 
 #include<unsupported/Eigen/AlignedVector3>
 
+#ifndef MINIEIGEN_OVERRIDE
 // integral type for indices, to avoid compiler warnings with int
 typedef Eigen::Matrix<int,1,1>::Index Index;
 
@@ -57,6 +60,7 @@ typedef Eigen::AlignedBox<Real,2> AlignedBox2r;
 	typedef Eigen::Matrix<complex<Real>,Eigen::Dynamic,Eigen::Dynamic> MatrixXcr;
 #endif
 
+#endif
 
 #include<string>
 using std::string;
@@ -71,6 +75,7 @@ namespace py=boost::python;
 using boost::lexical_cast;
 #include<boost/static_assert.hpp>
 
+#ifndef MINIEIGEN_OVERRIDE
 /**** double-conversion helpers *****/
 #include"double-conversion/double-conversion.h"
 
@@ -131,6 +136,7 @@ static inline string num_to_string(const double& num, int pad=0){ return doubleT
 	}
 #endif
 
+#endif
 
 /*** getters and setters with bound guards ***/
 static inline void IDX_CHECK(Index i,Index MAX){ if(i<0 || i>=MAX) { PyErr_SetString(PyExc_IndexError,("Index "+lexical_cast<string>(i)+" out of range 0.." + lexical_cast<string>(MAX-1)).c_str()); py::throw_error_already_set(); } }

--- a/src/visitors.hpp
+++ b/src/visitors.hpp
@@ -98,11 +98,16 @@ class MatrixBaseVisitor: public py::def_visitor<MatrixBaseVisitor<MatrixBaseT> >
 	static MatrixBaseT __iadd__(MatrixBaseT& a, const MatrixBaseT& b){ a+=b; return a; };
 	static MatrixBaseT __isub__(MatrixBaseT& a, const MatrixBaseT& b){ a-=b; return a; };
 
-	template<typename Scalar2> static MatrixBaseT __mul__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a*scalar; }
-	template<typename Scalar2> static MatrixBaseT __imul__scalar(MatrixBaseT& a, const Scalar2& scalar){ a*=scalar; return a; }
-	template<typename Scalar2> static MatrixBaseT __rmul__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a*scalar; }
-	template<typename Scalar2> static MatrixBaseT __div__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a/scalar; }
-	template<typename Scalar2> static MatrixBaseT __idiv__scalar(MatrixBaseT& a, const Scalar2& scalar){ a/=scalar; return a; }
+	template<typename Scalar2> static typename boost::enable_if <std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __mul__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a*scalar; }
+	template<typename Scalar2> static typename boost::disable_if<std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __mul__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a*static_cast<Scalar>(scalar); }
+	template<typename Scalar2> static typename boost::enable_if <std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __imul__scalar(MatrixBaseT& a, const Scalar2& scalar){ a*=scalar; return a; }
+	template<typename Scalar2> static typename boost::disable_if<std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __imul__scalar(MatrixBaseT& a, const Scalar2& scalar){ a*=static_cast<Scalar>(scalar); return a; }
+	template<typename Scalar2> static typename boost::enable_if <std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __rmul__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a*scalar; }
+	template<typename Scalar2> static typename boost::disable_if<std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __rmul__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a*static_cast<Scalar>(scalar); }
+	template<typename Scalar2> static typename boost::enable_if <std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __div__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a/scalar; }
+	template<typename Scalar2> static typename boost::disable_if<std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __div__scalar(const MatrixBaseT& a, const Scalar2& scalar){ return a/static_cast<Scalar>(scalar); }
+	template<typename Scalar2> static typename boost::enable_if <std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __idiv__scalar(MatrixBaseT& a, const Scalar2& scalar){ a/=scalar; return a; }
+	template<typename Scalar2> static typename boost::disable_if<std::is_convertible<Scalar2,const Scalar&>,MatrixBaseT>::type __idiv__scalar(MatrixBaseT& a, const Scalar2& scalar){ a/=static_cast<Scalar>(scalar); return a; }
 
 	template<typename Scalar, class PyClass> static	void visit_reductions_noncomplex(PyClass& cl, typename boost::enable_if_c<Eigen::NumTraits<Scalar>::IsComplex >::type* dummy = 0){ /* do nothing*/ }
 	template<typename Scalar, class PyClass> static	void visit_reductions_noncomplex(PyClass& cl, typename boost::disable_if_c<Eigen::NumTraits<Scalar>::IsComplex >::type* dummy = 0){


### PR DESCRIPTION
Hi Vaclav,

I have implemented [high precision types](https://yade-dev.gitlab.io/-/trunk/-/jobs/438987804/artifacts/install/share/doc/yade-ci/html/HighPrecisionReal.html) in Yade. See the [latest pipeline](https://gitlab.com/yade-dev/trunk/pipelines/118166972) for instance:

**Tests**

* [`long double`](https://gitlab.com/yade-dev/trunk/-/jobs/438530847)
* [`boost float128`](https://gitlab.com/yade-dev/trunk/-/jobs/438530848)
* [`boost mpfr`](https://gitlab.com/yade-dev/trunk/-/jobs/438530849)
* [`boost cpp_bin_float`](https://gitlab.com/yade-dev/trunk/-/jobs/438530850)

**Checks**

* [`long double`](https://gitlab.com/yade-dev/trunk/-/jobs/438530863)
* [`boost float128`](https://gitlab.com/yade-dev/trunk/-/jobs/438530864)
* [`boost mpfr`](https://gitlab.com/yade-dev/trunk/-/jobs/438530865)
* [`boost cpp_bin_float`](https://gitlab.com/yade-dev/trunk/-/jobs/438530866)

**Test GUI screenshots**

* [`long double`](https://gitlab.com/yade-dev/trunk/-/jobs/438530847/artifacts/browse/screenshots/)
* [`boost float128`](https://gitlab.com/yade-dev/trunk/-/jobs/438530848/artifacts/browse/screenshots/)
* [`boost mpfr`](https://gitlab.com/yade-dev/trunk/-/jobs/438530849/artifacts/browse/screenshots/)
* [`boost cpp_bin_float`](https://gitlab.com/yade-dev/trunk/-/jobs/438530850/artifacts/browse/screenshots/)

And `quad double` with 62 decimal places (package libqd-dev) is in the works with [boost developers](https://github.com/boostorg/multiprecision/issues/184).

To make it possible I needed an `#ifndef` to be able to typedef a different `Real` type. Then some of these types had disabled implicit conversions, and so I needed to write `static_cast<…>`. This is conditional with `boost::disable_if<std::is_convertible<…>>` so that the code remains exactly the same when type is implicitly convertible (previous behavior).

Usually minieigen comes as a precompiled package. For some types this is not possible, because precision is specified during compilation. And so minieigen sources are needed in `/usr/include/minieigen`, then in Yade they are used [like this](https://gitlab.com/yade-dev/trunk/-/blob/master/py/high-precision/_ExposeMatrices.cpp). Maybe someday we will have a debian/ubuntu package yade-float128 and an accompanying package minieigen-float128 :)

all the best
Janek