### PR TITLE
Transfer maintenance of miniEigen to yade-dev team.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,7 @@
+The miniEigen project is now maintained by yade-dev team. The official
+repository has been moved to: https://gitlab.com/yade-dev/minieigen
+
+
 This is miniEigen, small wrapper for the http://eigen.tuxfamily.org library.
 Home of this project is at http://www.launchpad.net/minieigen/. The code is
 licensed under the LGPLv3. The author is Václav Šmilauer <eu@doxos.eu>.


### PR DESCRIPTION
Hi Vaclav,

we have discussed [this matter](https://github.com/eudoxos/minieigen/pull/24#issuecomment-586921751) with Bruno and Anton, and we would like to take over the maintenance of minieigen. We have already forked your repository [here](https://gitlab.com/yade-dev/minieigen).

I suppose that to complete the transfer it would be appropriate to update accordingly the readme in this repository. I suggest this PR.

Thank you!

all the best 
Janek